### PR TITLE
Be more precise in the statement of the license

### DIFF
--- a/about.html
+++ b/about.html
@@ -3,6 +3,6 @@ layout: default
 title: About
 ---
 
-<p>TikZiT is an open source project licensed under the <a href="https://www.gnu.org/licenses/gpl-3.0.en.html">GNU General Public License, Version 3</a>. It is maintained primarily by <a href="https://www.cs.ru.nl/A.Kissinger/">Aleks Kissinger</a>, with contributions (notably the TikZ parser) from <a href="https://github.com/randomguy3">Alexander Merry</a>, <a href="http://homepages.inf.ed.ac.uk/cheunen/">Chris Heunen</a>, and <a href="https://github.com/gnzzz">K. Johan Paulsson</a>.</p>
+<p>TikZiT is an open source project licensed under the <a href="https://www.gnu.org/licenses/gpl-3.0.en.html">GNU General Public License, Version 3</a> (or, at your option, any later version). It is maintained primarily by <a href="https://www.cs.ru.nl/A.Kissinger/">Aleks Kissinger</a>, with contributions (notably the TikZ parser) from <a href="https://github.com/randomguy3">Alexander Merry</a>, <a href="http://homepages.inf.ed.ac.uk/cheunen/">Chris Heunen</a>, and <a href="https://github.com/gnzzz">K. Johan Paulsson</a>.</p>
 
 <p>Please file bug reports or issue requests <a href="https://github.com/tikzit/tikzit/issues">here</a>.</p>


### PR DESCRIPTION
The source code comments declare TikZiT to be under the terms of version 3 or any later version of the GPL. This pull request reflects this in the *about* page. Up to now, it states that TikZiT is available only under the terms of exactly version 3 of the GPL.

(I noticed this issue when packaging TikZiT for NixOS, which requires license metadata.)